### PR TITLE
Compatibility Fix: Convex Object Breaker no longer overrides userData

### DIFF
--- a/packages/ammoPhysics/src/convexObjectBreaker.ts
+++ b/packages/ammoPhysics/src/convexObjectBreaker.ts
@@ -392,6 +392,7 @@ ConvexObjectBreaker.prototype = {
         object1 = new Mesh(new ConvexBufferGeometry(points1), object.material)
         object1.position.copy(this.tempCM1)
         object1.quaternion.copy(object.quaternion)
+        object1.userData = object.userData
         
         this.prepareBreakableObject(
           object1,
@@ -413,6 +414,7 @@ ConvexObjectBreaker.prototype = {
         object2 = new Mesh(new ConvexBufferGeometry(points2), object.material)
         object2.position.copy(this.tempCM2)
         object2.quaternion.copy(object.quaternion)
+        object2.userData = object.userData
 
         this.prepareBreakableObject(
           object2,

--- a/packages/ammoPhysics/src/convexObjectBreaker.ts
+++ b/packages/ammoPhysics/src/convexObjectBreaker.ts
@@ -97,7 +97,7 @@ ConvexObjectBreaker.prototype = {
       console.error('THREE.ConvexObjectBreaker.prepareBreakableObject(): Parameter object must have a BufferGeometry.')
     }
 
-    object.userData.ammoPhysicsData = {} // initialise our new data container
+    object.userData.ammoPhysicsData = {} // initialise our new data container - would be best to move this to ExtendedObject and not rely on userData at all for best compatibility
     var ammoPhysicsData = object.userData.ammoPhysicsData // get reference to it
     ammoPhysicsData.mass = mass
     ammoPhysicsData.velocity = velocity.clone()
@@ -345,11 +345,7 @@ ConvexObjectBreaker.prototype = {
     }
 
     // Calculate debris mass (very fast and imprecise):
-
-    var newMass = 0.5
-    // if(object.userData.ammoPhysicsData) {
-      newMass = object.userData.ammoPhysicsData.mass * 0.5
-    // }
+    var newMass = object.userData.ammoPhysicsData.mass * 0.5
 
     // Calculate debris Center of Mass (again fast and imprecise)
     this.tempCM1.set(0, 0, 0)
@@ -387,14 +383,6 @@ ConvexObjectBreaker.prototype = {
     var object2 = null
 
     var numObjects = 0
-
-
-    var newVelocity = 0
-    var newAngularVelocity = 0
-    // if (object.userData.ammoPhysicsData !== undefined) {
-      newVelocity = object.userData.ammoPhysicsData.velocity
-      newAngularVelocity = object.userData.ammoPhysicsData.angularVelocity
-    // }
     
     /**
      * MOD: Wrapped in try catch block to avoid errors
@@ -408,8 +396,8 @@ ConvexObjectBreaker.prototype = {
         this.prepareBreakableObject(
           object1,
           newMass,
-          newVelocity,
-          newAngularVelocity,
+          object.userData.ammoPhysicsData.velocity,
+          object.userData.ammoPhysicsData.angularVelocity,
           2 * radius1 > this.minSizeForBreak
         )
 
@@ -429,8 +417,8 @@ ConvexObjectBreaker.prototype = {
         this.prepareBreakableObject(
           object2,
           newMass,
-          newVelocity,
-          newAngularVelocity,
+          object.userData.ammoPhysicsData.velocity,
+          object.userData.ammoPhysicsData.angularVelocity,
           2 * radius2 > this.minSizeForBreak
         )
 

--- a/packages/ammoPhysics/src/physics.ts
+++ b/packages/ammoPhysics/src/physics.ts
@@ -383,19 +383,19 @@ class AmmoPhysics extends EventEmitter {
       const fractureImpulse = 5 //250
       const MAX_FRAGMENT_DEPTH = 2
 
-      // since the library convexBreaker makes use of three's userData
-      // we have to clone the necessary params to threeObjectX.userData
+      // since the library convexBreaker makes use of three's userData.ammoPhysicsData
+      // we have to clone the necessary params to threeObjectX.userData.ammoPhysicsData
       // TODO improve this
 
       this.emptyV3.set(0, 0, 0)
-      threeObject0.userData = {
+      threeObject0.userData.ammoPhysicsData = {
         mass: 1,
         velocity: this.emptyV3,
         angularVelocity: this.emptyV3,
         breakable: breakable0,
         physicsBody: body0
       }
-      threeObject1.userData = {
+      threeObject1.userData.ammoPhysicsData = {
         mass: 1,
         velocity: this.emptyV3,
         angularVelocity: this.emptyV3,
@@ -414,8 +414,8 @@ class AmmoPhysics extends EventEmitter {
           const vel = body0.getLinearVelocity()
           const angVel = body0.getAngularVelocity()
           const fragment = debris[j] as ExtendedObject3D
-          fragment.userData.velocity.set(vel.x(), vel.y(), vel.z())
-          fragment.userData.angularVelocity.set(angVel.x(), angVel.y(), angVel.z())
+          fragment.userData.ammoPhysicsData.velocity.set(vel.x(), vel.y(), vel.z())
+          fragment.userData.ammoPhysicsData.angularVelocity.set(angVel.x(), angVel.y(), angVel.z())
 
           this.createDebrisFromBreakableObject(fragment, threeObject0)
         }
@@ -432,8 +432,8 @@ class AmmoPhysics extends EventEmitter {
           const vel = body1.getLinearVelocity()
           const angVel = body1.getAngularVelocity()
           const fragment = debris[j] as ExtendedObject3D
-          fragment.userData.velocity.set(vel.x(), vel.y(), vel.z())
-          fragment.userData.angularVelocity.set(angVel.x(), angVel.y(), angVel.z())
+          fragment.userData.ammoPhysicsData.velocity.set(vel.x(), vel.y(), vel.z())
+          fragment.userData.ammoPhysicsData.angularVelocity.set(angVel.x(), angVel.y(), angVel.z())
 
           this.createDebrisFromBreakableObject(fragment, threeObject1)
         }

--- a/packages/threeGraphics/src/plugins/loaders.ts
+++ b/packages/threeGraphics/src/plugins/loaders.ts
@@ -91,17 +91,6 @@ export default class Loaders {
     })
   }
 
-  public image(url: string): Promise<HTMLImageElement> {
-    const key = this.cache.get(url)
-    url = key ? key : url
-
-    return new Promise(resolve => {
-      this.imageLoader.load(url, img => {
-        return resolve(img)
-      })
-    })
-  }
-
   public svg(url: string): Promise<SVGResult> {
     const key = this.cache.get(url)
     url = key ? key : url

--- a/packages/threeGraphics/src/plugins/loaders.ts
+++ b/packages/threeGraphics/src/plugins/loaders.ts
@@ -91,6 +91,17 @@ export default class Loaders {
     })
   }
 
+  public image(url: string): Promise<HTMLImageElement> {
+    const key = this.cache.get(url)
+    url = key ? key : url
+
+    return new Promise(resolve => {
+      this.imageLoader.load(url, img => {
+        return resolve(img)
+      })
+    })
+  }
+
   public svg(url: string): Promise<SVGResult> {
     const key = this.cache.get(url)
     url = key ? key : url


### PR DESCRIPTION
I have made a little change to the way convex objects store their data upon subdivision. Instead of overriding userData, it uses a new child object of userData. This adds back the utility of an object's userData, as previously the userData was overridden by the division. The userData is duplicated between both objects.

I suggest moving the data stored to the ExtendedObject itself, rather than relying on userData (as it is internal to enable3d/ammoPhysics, and not user derived). This will improve compatibility further and allow an object to easily contain any additional physics information.

Please ignore the 1st and 3rd commits, I had a previous feature I wanted to implemented but decided against it, and it still showed up here. Sorry about that, still new to git.