### PR TITLE
Fixed .on.collision with event=end firing for wrong objects

### DIFF
--- a/packages/ammoPhysics/src/physics.ts
+++ b/packages/ammoPhysics/src/physics.ts
@@ -422,7 +422,7 @@ class AmmoPhysics extends Events {
 
           // handle collision events
           if (checkCollisions0 || checkCollisions1) {
-            const names = [threeObject0.name, threeObject1.name].sort()
+            const names = [threeObject0.uuid, threeObject1.uuid].sort()
             const combinedName = `${names[0]}__${names[1]}`
 
             if (this.earlierDetectedCollisions.find(el => el.combinedName === combinedName)) event = 'collision'
@@ -526,8 +526,8 @@ class AmmoPhysics extends Events {
       const { combinedName } = el
       if (!detectedCollisions.find(el => el.combinedName === combinedName)) {
         const split = combinedName.split('__')
-        const obj0 = this.rigidBodies.find(obj => obj.name === split[0])
-        const obj1 = this.rigidBodies.find(obj => obj.name === split[1])
+        const obj0 = this.rigidBodies.find(obj => obj.uuid === split[0])
+        const obj1 = this.rigidBodies.find(obj => obj.uuid === split[1])
         const event = 'end'
         if (obj0 && obj1) this.collisionEvents.emit('collision', { bodies: [obj0, obj1], event })
       }


### PR DESCRIPTION
Issue: Physics collision "end" event may be wrong when there are cloned objects in headless mode (probably also in none headless but not tested)

In this example we can expect that everything is already set up and the physics are updated in a consistent timestep of 1/60s

```typescript
const mesh = new THREE.Mesh(someGeometry, someMaterial);
mesh.name = "test"; // some arbitrary name, because exported files from blender always have names set

const clone = mesh.clone();
console.log(clone.name); // => test

// set data
mesh.userData = { name: "original" };
clone.userData = { name: "clone" };

mesh.position.set(0, 100, 0); // clearly higher in the air
clone.position.set(0, 50, 0); // lower, should collide earlier?

// both are dynamic objects with the same config
physics.add.existing(mesh, { /* some config here */ });
physics.add.existing(clone, { /* same config here */ });

const ground = physics.add.box({
    width: 10,
    height: 1,
    depth: 10,
    x: 0,
    y: 0,
    z: 0,
    collisionFlags: 1 // make static
});

ground.body.on.collision((other, event) => {
    console.log("collision", other.userData.name, event);
});
```

Expected output:
```
collision clone start
~5x collision clone collision
collision clone end

collision original start
~5x collision original collision
collision original end
```

Actual output:
```
collision clone start
~5x collision clone collision
collision original end <-- this is the issue here

collision original start
~5x collision original collision
collision original end
```

This happens because Enable3d uses the name property to filter which collisions were present in the last run and compares the names of the 2 objects joined with `__`.

A simple fix for this is using the `.uuid` property of the THREE elements. They are unique to clones and cannot contain double underscores (why ever someone would name their objects with double underscores in the first place)