### PR TITLE
Rollup compatibility (StencilJS)

### DIFF
--- a/packages/ammoPhysics/src/physics.ts
+++ b/packages/ammoPhysics/src/physics.ts
@@ -21,13 +21,7 @@ import Constraints from './constraints'
 import { Events } from '@yandeu/events'
 import { Geometry } from './externals'
 import { BufferGeometry, Euler, Matrix4, Quaternion, REVISION, Scene, Vector3 } from 'three'
-const {
-  createHACDShapes,
-  createHullShape,
-  createTriMeshShape,
-  createVHACDShapes,
-  iterateGeometries
-} = require('./three-to-ammo')
+import { createHACDShapes, createHullShape, createTriMeshShape, createVHACDShapes, iterateGeometries} from './three-to-ammo'
 import { createTorusShape } from './torusShape'
 import Factories from '@enable3d/common/dist/factories'
 import { CollisionEvents } from './collisionEvents'


### PR DESCRIPTION
In new versions of Rollup, it is possible to allow mixed import/require in the same file.  But in old version you can either have a commonJS module or an ES6 one 

With the new plugin it is possible to allow it with :
 
``` commonjs({transformMixedEsModules:true}) ```