### PR TITLE
Let people know it works with modern Phaser versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Enable3d now depends on the dependencies below.
   "three-csg-ts": "^3.1.10"
 }
 ```
+(But it also works on latest Phaser versions like 3.60 & 3.70)
 
 ## Useful Packages
 


### PR DESCRIPTION
The readme makes it look like the only compatible version is 3.55 but i've tested it against phaser 3.70 and... I had to make 0 changes. It just kept working like before!
On my game I:
- Load/unload scenes. 
- Load multiple scenes at once.
- Load FBX, gltf and glb files
- Play animations on them
- Move the third camera both by position and by methods like lookAt
- I have physics
- I intersectObjects

Nothing exploded/changed the way it worked :o
Fucking awesome, now i can have the latest things like DynamicTextures!

FPS also remain the same: 240 average with 295 DC (yeah.. i should work on that...)