### PR TITLE
Added support of InterleavedBuffers for collision shapes

### DIFF
--- a/packages/ammoPhysics/src/three-to-ammo.ts
+++ b/packages/ammoPhysics/src/three-to-ammo.ts
@@ -730,8 +730,28 @@ export const iterateGeometries = (function () {
         }
         // todo: might want to return null xform if this is the root so that callers can avoid multiplying
         // things by the identity matrix
+        let positions;
+        if (mesh.geometry.isBufferGeometry) {
+          const bufferPositions = mesh.geometry.attributes.position;
+
+          if (bufferPositions.isInterleavedBufferAttribute) {
+            positions = new Float32Array(bufferPositions.count * bufferPositions.itemSize);
+            let interleavedInd = bufferPositions.offset;
+            let positionInd = 0;
+
+            while (positionInd < positions.length) {
+              for (let elemInd = 0; elemInd < bufferPositions.itemSize; elemInd++) {
+                positions[positionInd++] = bufferPositions.array[interleavedInd + elemInd]
+              }
+              interleavedInd += bufferPositions.data.stride;
+            }
+          } else {
+            positions = bufferPositions.array;
+          }
+        }
+
         cb(
-          mesh.geometry.isBufferGeometry ? mesh.geometry.attributes.position.array : mesh.geometry.vertices,
+          mesh.geometry.isBufferGeometry ? positions : mesh.geometry.vertices,
           transform.elements,
           mesh.geometry.index ? mesh.geometry.index.array : null
         )


### PR DESCRIPTION
Added support of byteStride property in InterleavedBuffers for collision shapes:
https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#data-alignment